### PR TITLE
fix: add more details on where to find the keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ module.exports = {
         headers: { 
           'Prismic-Ref': ``, // useMasterRef will overload this line
           'Authorization': `Token `,
-        }
+        },
 
         useMasterRef: true // undefined by default
       }
@@ -71,6 +71,10 @@ The prefix to be used for your imported schema's field types.
 - Type: `object`
 
 An object of headers to be passed along with your request to the API endpoint. This will generally be used to authenticate your request.
+
+The `Prismic-Ref` can be found [here](https://user-guides.prismic.io/en/articles/2864318-view-your-api-easily-with-the-api-browser), it is called `Master Ref` there.
+
+For the `Authorization` token, follow this [guide](https://user-guides.prismic.io/en/articles/1036153-generating-an-access-token), it should look like something like ``` `Authorization': `Token ${process.env.AUTH_TOKEN}` ```
 
 #### useMasterRef
 


### PR DESCRIPTION
Should be even more faster for somebody starting a project to get and running. :running_man: 

Did not achieved to make the boolean `useMasterRef` to work in any way tho. Not a big deal I guess. :thinking: 

The `Master` key can actually be found at `https://<repo-name>.prismic.io/api/v2`, the docs are talking about it [here](https://prismic.io/docs/rest-api/basics/introduction-to-the-content-query-api) but not on the Vue section... 